### PR TITLE
Use tr instead of perl in tracker-error script

### DIFF
--- a/qbittorrent/root/usr/local/bin/tracker-error
+++ b/qbittorrent/root/usr/local/bin/tracker-error
@@ -9,7 +9,7 @@ add_hashes=($(cmd_curl "${api_url_base}/sync/maindata" | jq -r '.torrents | to_e
 
 ## 调整标签
 if [[ -n ${add_hashes[@]} ]]; then
-    echo "hashes=$(echo "${add_hashes[@]}" | perl -pe 's| |\||g')&tags=${tag_name}" | cmd_curl_post -d @- ${api_url_base}/torrents/addTags
+    echo "hashes=$(echo "${add_hashes[@]}" | tr ' ' '|')&tags=${tag_name}" | cmd_curl_post -d @- ${api_url_base}/torrents/addTags
 
     ## 发送通知
     TRACKER_ERROR_COUNT_MIN=${TRACKER_ERROR_COUNT_MIN:-3}


### PR DESCRIPTION
tracker-error 脚本执行时报错：
```sh
root@DS220Plus:~# docker exec qbittorrent tracker-error
/usr/local/bin/tracker-error: line 12: perl: command not found
(N) 2026-05-29T01:45:02 - [notify] 发送Telegram通知成功
(N) 2026-05-29T01:45:02 - [notify] 发送企业微信群BOT通知成功
```

所以使用 `tr` 来替换 `perl`，替换后执行日志：
```
root@NAS-qBitTorrent:/data $ tracker-error
(N) 2026-05-29T02:10:46 - [notify] 发送Telegram通知成功
(N) 2026-05-29T02:10:46 - [notify] 发送企业微信群BOT通知成功
```

观察 qbittrrent Web-UI 可以发现 `TrackerError` 标签已经添加成功了。
<img width="1049" height="364" alt="图片" src="https://github.com/user-attachments/assets/02af3575-5a4b-48ab-b447-07d43a6453a3" />
